### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: build-test-deploy-to-s3
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Jason-nzd/supermarket-prices-nextjs/security/code-scanning/19](https://github.com/Jason-nzd/supermarket-prices-nextjs/security/code-scanning/19)

To fix the problem, add a `permissions` block to the workflow or the specific job(s) to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, since the workflow only checks out code and deploys to AWS (with no repository write actions), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best practice is to add the following at the top level of the workflow file, just after the `name` field and before `on`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
